### PR TITLE
added function to compute homography matrix

### DIFF
--- a/src/CameraGeometry.jl
+++ b/src/CameraGeometry.jl
@@ -3,4 +3,9 @@ module CameraGeometry
 # package code goes here
 using Images
 
+include("homography.jl")
+
+export
+    gethomography
+
 end # module

--- a/src/homography.jl
+++ b/src/homography.jl
@@ -1,0 +1,71 @@
+"""
+gethomography estimates the 3x3 homography matrix from src to des points
+"""
+
+function gethomography(src::Array{CartesianIndex{2},1}, des::Array{CartesianIndex{2},1})
+    if length(src)!=length(des)
+        error("Different number of src and des points!")
+    end
+
+    n_points=length(src)
+
+    if n_points<4
+        error("Not enough points to estimate projection matrix")
+    end
+
+    xs = zeros(n_points)
+    ys = zeros(n_points)
+    xd = zeros(n_points)
+    yd = zeros(n_points)
+
+    for i in 1:n_points
+        xs[i]=src[i][1]
+        ys[i]=src[i][2]
+        xd[i]=des[i][1]
+        yd[i]=des[i][2]
+    end
+
+    #if homography can be exactly determined
+    if n_points==4
+        A = zeros(2*n_points,8)
+        A[1:4,1]=xs
+        A[1:4,2]=ys
+        A[1:4,3]=1
+        A[5:8,4]=xs
+        A[5:8,5]=ys
+        A[5:8,6]=1
+        A[1:4,7]=-xs.*xd
+        A[5:8,7]=-xs.*yd
+        A[1:4,8]=-ys.*xd
+        A[5:8,8]=-ys.*yd
+
+        B = zeros(2*n_points)
+        B[1:4]=xd
+        B[5:8]=yd
+
+        x = inv(A)*B
+
+        push!(x,1)
+        H = transpose(reshape(x, 3, 3))
+        return H
+    end
+
+    A = zeros(2*n_points,9)
+    A[1:n_points,1] = xs
+    A[1:n_points,2] = ys
+    A[1:n_points,3] = 1
+    A[n_points+1:2*n_points,4]=xs
+    A[n_points+1:2*n_points,5]=ys
+    A[n_points+1:2*n_points,6]=1
+    A[1:n_points,7] = -xs.*xd
+    A[n_points+1:2*n_points,7]= -xs.*yd
+    A[1:n_points,8] = -ys.*xd
+    A[n_points+1:2*n_points,8]= -ys.*yd
+    A[1:n_points,9] = -xd
+    A[n_points+1:2*n_points,9]= -yd
+
+    _, _, v = svd(A, thin=true)
+    H=transpose(reshape(v[:,end]./v[end][end],3,3))
+
+    return H
+end

--- a/test/homography.jl
+++ b/test/homography.jl
@@ -1,0 +1,31 @@
+using Base.Test
+
+@testset "homography" begin
+    src=CartesianIndex{2}[]
+    push!(src, CartesianIndex(1,1))
+    push!(src, CartesianIndex(2,1))
+    push!(src, CartesianIndex(3,1))
+    push!(src, CartesianIndex(3,3))
+    push!(src, CartesianIndex(1,3))
+
+    des=CartesianIndex{2}[]
+    push!(des, CartesianIndex(1,1))
+    push!(des, CartesianIndex(3,1))
+    push!(des, CartesianIndex(5,1))
+    push!(des, CartesianIndex(4,4))
+    push!(des, CartesianIndex(2,4))
+
+    H = gethomography(src, des)
+
+    @test H[3,3]==1
+
+    p=H*[1, 1, 1]
+    p/=p[3]
+    @test_approx_eq p[1] 1
+    @test_approx_eq p[2] 1
+
+    p=H*[1, 2, 1]
+    p/=p[3]
+    @test_approx_eq p[1] 5/3
+    @test_approx_eq p[2] 3
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ module CameraGeometryTest
 # write your own tests here
 using FactCheck, CameraGeometry, Base.Test, Images
 
+include("homography.jl")
 
 isinteractive() || FactCheck.exitstatus()
 


### PR DESCRIPTION
The function computes the homography matrix from src points to des points. The inputs are given as an array of CartesianIndex and the function returns a 3x3 array.